### PR TITLE
Remove unneeded namespace guard from apply trap.

### DIFF
--- a/lib/internal/bootstrap/loaders.js
+++ b/lib/internal/bootstrap/loaders.js
@@ -271,9 +271,7 @@
 
           const p = new Proxy(value, {
             apply: (t, thisArg, args) => {
-              if (thisArg === proxy || (this.reflect !== undefined &&
-                  this.reflect.namespace !== undefined &&
-                  thisArg === this.reflect.namespace)) {
+              if (thisArg === proxy) {
                 thisArg = target;
               }
               return ReflectApply(t, thisArg, args);


### PR DESCRIPTION
Following up on commenting my own implementation I went to check the added namespace check, since the V8 bug just mentions proxy objects and not null-prototyped objects. It turns out things work without the namespace guard.